### PR TITLE
Fixing Assertion error

### DIFF
--- a/activity.py
+++ b/activity.py
@@ -184,10 +184,7 @@ class Activity(activity.Activity):
         # select color
         item = Gtk.ToolItem()
         _fill_color = ColorToolButton()
-        c = Gdk.RGBA()
-        c.red = 21588
-        c.green = 47546
-        c.blue = 18504
+        c = Gdk.Color(red=21588, green=47546, blue=18504)
         _fill_color.set_color(c)
         _fill_color.connect('notify::color', self.color_back_change)
         item.add(_fill_color)
@@ -229,8 +226,7 @@ class Activity(activity.Activity):
         # select color
         item = Gtk.ToolItem()
         _fill_color = ColorToolButton()
-        c = Gdk.RGBA()
-        c.red = 65535
+        c = Gdk.Color(red=65535, green=0, blue=0)
         _fill_color.set_color(c)
         _fill_color.connect('notify::color', self.color_owner_change)
         item.add(_fill_color)


### PR DESCRIPTION
The activity used import of colorbutton as "ColorToolButton" and used
Gdk.RGBA() for selecting color.Starting the activity resulted in an assertion
error.The assertion error was probably caused because the set_color function in
colorbutton.py in sugar3/graphics handles Gdk.Color instead of Gdk.RGBA.

Now using Gdk.Color instead of Gdk.RGBA fixed the assertion error.